### PR TITLE
fixed some clippy warnings

### DIFF
--- a/src/blocks/dynamic.rs
+++ b/src/blocks/dynamic.rs
@@ -39,8 +39,7 @@ const CODE_LENGTHS_UNSHUFFLE : [usize; 19] =
 
 impl<'a> BlockDynamic<'a> {
     pub fn new(input: &'a mut BitSource, output: &'a mut OutputBuffer)
-        ->  BlockDynamicBuilder<'a> {
-
+            -> BlockDynamicBuilder<'a> {
         BlockDynamicBuilder{ input, output }
     }
 }
@@ -89,7 +88,7 @@ impl<'a> BlockDynamicBuilder<'a> {
         let mut huff_lengths: Vec<u8> = vec![];
         let mut previous : Option<u8> = None;
         while huff_lengths.len() < size {
-            match Huffman::get_code(&code_huffman, self.input)? as u8 {
+            match Huffman::get_code(code_huffman, self.input)? as u8 {
                 c @ 0...15 => {
                     huff_lengths.push(c);
                     previous = Some(c);

--- a/src/blocks/huffman.rs
+++ b/src/blocks/huffman.rs
@@ -10,6 +10,7 @@ pub enum HuffmanNode {
 pub type Huffman = HuffmanNode;
 
 type HuffmanCode = Vec<(u8, u16, u32)>;
+type HuffmanSlice = [(u8, u16, u32)];
 
 impl HuffmanNode {
     pub fn build(codes : Vec<u8>) -> GzipResult<Self> {
@@ -60,18 +61,12 @@ impl HuffmanNode {
         ans
     }
 
-    fn build_trie(huffman: &HuffmanCode,
+    fn build_trie(huffman: &HuffmanSlice,
                   start: usize, end: usize, mask: u32) -> GzipResult<Self> {
         if start == end {
             return Ok(HuffmanNode::Code(huffman[start].1));
         }
-        let mut first = 0;
-        for i in start..(end + 1) {
-            if huffman[i].2 & mask > 0 {
-                first = i;
-                break;
-            }
-        }
+        let first = huffman[start..(end + 1)].iter().position(|x| x.2 & mask > 0).unwrap_or(0);
         if first == 0 {
             return Err(GzipError::InternalError);
         }

--- a/src/buffers/channel.rs
+++ b/src/buffers/channel.rs
@@ -92,7 +92,7 @@ impl ReceiverBuffer {
     }
 
     fn put_data(&mut self, data: Vec<u8>) -> GzipResult<()> {
-        for d in data.iter() {
+        for d in &data {
             self.buffer[self.pos] = *d;
             self.pos = (self.pos + 1) & 32767;
         }

--- a/src/buffers/circular.rs
+++ b/src/buffers/circular.rs
@@ -26,7 +26,7 @@ impl OutputBuffer for CircularBuffer {
     }
 
     fn put_data(&mut self, data: Vec<u8>) -> GzipResult<()> {
-        for d in data.iter() {
+        for d in &data {
             self.buffer[self.pos] = *d;
             self.pos = (self.pos + 1) & 32767;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -172,7 +172,7 @@ impl GzipDecoder {
                 self.header.original_name = Some(name);
             }
         }
-        return Ok(());
+        Ok(())
     }
 
     fn translate_os(&self) -> &'static str {
@@ -214,7 +214,7 @@ fn choose_buffer(sink: ByteSinkProvider) -> GzipResult<Box<OutputBuffer>> {
     }
 }
 
-fn choose_source(input: &String) -> GzipResult<Box<ByteSource>> {
+fn choose_source(input: &str) -> GzipResult<Box<ByteSource>> {
     match get_context!(SOURCE) {
         0 => Ok(Box::new(VecSource::from_file(input)?)),
         1 => Ok(Box::new(BufferSource::from_file(input)?)),
@@ -224,7 +224,7 @@ fn choose_source(input: &String) -> GzipResult<Box<ByteSource>> {
     }
 }
 
-fn read_gzip<'a>(input: &'a String, output: String) -> GzipResult<()> {
+fn read_gzip(input: &str, output: String) -> GzipResult<()> {
     let sink = choose_sink(output)?;
     let buffer = choose_buffer(sink)?;
     let source  = choose_source(input)?;
@@ -288,10 +288,10 @@ fn main() {
         return;
     }
 
-    let ref input = matches.free[0];
+    let input = &matches.free[0];
     let output : String = matches.free[1].clone();
     println!("Reading from {}, writing to {}", input, output);
-    match read_gzip(&input, output) {
+    match read_gzip(input, output) {
         Ok(_) => println!("Finished"),
         Err(error) => println!("Error: {}", error)
     }

--- a/src/sources/buffersource.rs
+++ b/src/sources/buffersource.rs
@@ -18,7 +18,7 @@ impl ByteSource for BufferSource {
 }
 
 impl BufferSource {
-    pub fn from_file(name: &String) -> GzipResult<Self> {
+    pub fn from_file(name: &str) -> GzipResult<Self> {
         use GzipError::*;
         let file = File::open(name).or(Err(CantOpenFile))?;
         Ok(BufferSource{ file: BufReader::new(file).bytes() })

--- a/src/sources/vecbufsource.rs
+++ b/src/sources/vecbufsource.rs
@@ -27,7 +27,7 @@ impl ByteSource for VecBufSource {
 }
 
 impl VecBufSource {
-    pub fn from_file(name: &String) -> GzipResult<Self> {
+    pub fn from_file(name: &str) -> GzipResult<Self> {
         use GzipError::*;
         let data = vec![0; SIZE];
         let file = File::open(name).or(Err(CantOpenFile))?;

--- a/src/sources/vecsource.rs
+++ b/src/sources/vecsource.rs
@@ -21,7 +21,7 @@ impl ByteSource for VecSource {
 }
 
 impl VecSource {
-    pub fn from_file(name: &String) -> GzipResult<Self> {
+    pub fn from_file(name: &str) -> GzipResult<Self> {
         use GzipError::*;
         let mut data = vec![];
         let mut file = File::open(name).or(Err(CantOpenFile))?;

--- a/src/sources/widesource.rs
+++ b/src/sources/widesource.rs
@@ -34,7 +34,7 @@ impl ByteSource for WideSource {
 }
 
 impl WideSource {
-    pub fn from_file(name: &String) -> GzipResult<Self> {
+    pub fn from_file(name: &str) -> GzipResult<Self> {
         use GzipError::*;
         let mut data = vec![];
         let mut file = File::open(name).or(Err(CantOpenFile))?;


### PR DESCRIPTION
Those are mainly readability nits, but using `&str` instead of `&String` and `&[T]` instead of `&Vec<T>` will make your code more flexible, too.